### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/geeknik/token-guardian/security/code-scanning/1](https://github.com/geeknik/token-guardian/security/code-scanning/1)

To fix the error, add a `permissions:` block to the workflow file `.github/workflows/ci.yml`. This block can be set at the top level (applies to all jobs unless overridden per-job), or per-job (for job-specific control). As none of the jobs require write access to the repository, the least privilege setting is `contents: read`. This change should be made near the top of the workflow, beneath the `name:` and above the `on:` block, for maximum clarity and effect. No additional dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
