### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: write
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/geeknik/token-guardian/security/code-scanning/2](https://github.com/geeknik/token-guardian/security/code-scanning/2)

To fix this issue, add an explicit `permissions` block to the workflow. In this case, since the workflow builds, runs tests, publishes to npm, and uploads release assets, most steps only need `contents: read` (for checkout, etc.), but publishing a release asset via `softprops/action-gh-release` typically requires `contents: write`. Therefore, the minimum required permissions are `contents: write`. If no other workflow steps require further permissions, set the block at the top level of the workflow file (after the `name:` and before `on:`) to cover all jobs unless you want per-job overrides. 

Insert:

```yaml
permissions:
  contents: write
```
right after `name: Release`.

**Changes needed:**  
- Edit `.github/workflows/release.yml`
- Insert a `permissions` block after `name: Release` (line 1).
- No imports, methods, or variable definitions required, as this is a YAML workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
