### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/src/rotation/services/GitHubRotator.ts
+++ b/src/rotation/services/GitHubRotator.ts
@@ -244,7 +244,7 @@ export class GitHubRotator implements ServiceRotator {
           
           this.logger.info(`Retrying request (${retryCount}/${this.retryOptions.maxRetries})`, {
             delay,
-            url: config.url,
+            /* url: config.url, -- removed to avoid logging sensitive endpoint */,
             status: axiosError.response?.status,
             method: config.method
           });


### PR DESCRIPTION
Potential fix for [https://github.com/geeknik/token-guardian/security/code-scanning/4](https://github.com/geeknik/token-guardian/security/code-scanning/4)

The best fix is to restrict the information logged in the retry info statement (line 245) so that no potentially sensitive fields derived from the OAuth2 config (like endpoint URLs, headers, or other private values) are logged.  

Specifically:  
- Remove or redact the `url` field in the object being logged, replacing it with a generic label, or omitting it entirely.  
- Ensure that only non-sensitive metadata (like retry counts, status code, method) are logged.
- Do not log entire request configs, headers, or other OAuth2 attributes.
- No new imports are necessary.
- Edit the log statement on line 245 and ensure no sensitive data is revealed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
